### PR TITLE
[AUTH-2] Add additional user's information to JWT 'user_claims'.

### DIFF
--- a/api_server/auth/services/__init__.py
+++ b/api_server/auth/services/__init__.py
@@ -105,18 +105,26 @@ class AuthService(AbstractAuthService):
     async def _login(self, user: AuthUserInputSchema) -> None:
         db_user = await self.user_crud.get_user_by_username(username=user.username)
         if await self.verify_password(password=user.password, password_hash=db_user.password):
+            user_claims = {
+                'user_data': {
+                    'id': str(db_user.id),
+                    'email': db_user.email,
+                    'phone': db_user.phone_number,
+                },
+            }
             access_token = await self._create_jwt_token(
                 subject=user.username,
                 token_type=AuthJWTConstants.ACCESS_TOKEN_NAME.value,
                 time_unit=AuthJWTConstants.MINUTES.value,
                 time_amount=AuthJWTConstants.TOKEN_EXPIRE_60.value,
+                user_claims=user_claims,
             )
             refresh_token = await self._create_jwt_token(
                 subject=user.username,
                 token_type=AuthJWTConstants.REFRESH_TOKEN_NAME.value,
                 time_unit=AuthJWTConstants.DAYS.value,
                 time_amount=AuthJWTConstants.TOKEN_EXPIRE_7.value,
-
+                user_claims=user_claims,
             )
 
             self.Authorize.set_access_cookies(access_token)
@@ -127,7 +135,9 @@ class AuthService(AbstractAuthService):
                 detail=AuthExceptionMsgs.WRONG_USERNAME_OR_PASSWORD.value,
             )
 
-    async def _create_jwt_token(self, subject: str, token_type: str, time_amount: int, time_unit: str) -> str:
+    async def _create_jwt_token(
+            self, subject: str, token_type: str, time_amount: int, time_unit: str, user_claims: dict,
+    ) -> str:
         """Creates JWT access or refresh tokens.
 
         Args:
@@ -135,6 +145,7 @@ class AuthService(AbstractAuthService):
             token_type: string with token_type.
             time_amount: token lifetime amount.
             time_unit: token lifetime unit.
+            user_claims: additional user information.
 
         Returns:
         Return access or refresh token with set parameters.
@@ -144,7 +155,7 @@ class AuthService(AbstractAuthService):
             'refresh': self.Authorize.create_refresh_token,
         }
         expires_time = timedelta(**{time_unit: time_amount})
-        return CREATE_TOKEN_METHODS[token_type](subject=subject, expires_time=expires_time)
+        return CREATE_TOKEN_METHODS[token_type](subject=subject, expires_time=expires_time, user_claims=user_claims)
 
     async def _me(self) -> None:
         self.Authorize.jwt_required()
@@ -160,17 +171,20 @@ class AuthService(AbstractAuthService):
     async def _refresh_token(self) -> None:
         self.Authorize.jwt_refresh_token_required()
         current_user = self.Authorize.get_jwt_subject()
+        current_user_claims = {'user_data': self.Authorize.get_raw_jwt()['user_data']}
         access_token = await self._create_jwt_token(
             subject=current_user,
             token_type=AuthJWTConstants.ACCESS_TOKEN_NAME.value,
             time_unit=AuthJWTConstants.MINUTES.value,
             time_amount=AuthJWTConstants.TOKEN_EXPIRE_60.value,
+            user_claims=current_user_claims,
         )
         refresh_token = await self._create_jwt_token(
             subject=current_user,
             token_type=AuthJWTConstants.REFRESH_TOKEN_NAME.value,
             time_unit=AuthJWTConstants.DAYS.value,
             time_amount=AuthJWTConstants.TOKEN_EXPIRE_7.value,
+            user_claims=current_user_claims,
         )
         self.Authorize.set_access_cookies(access_token)
         self.Authorize.set_refresh_cookies(refresh_token)

--- a/api_server/common/tests/generics.py
+++ b/api_server/common/tests/generics.py
@@ -306,18 +306,26 @@ class TestMixin:
         Returns:
         newly created User object.
         """
+        user_claims = {
+            'user_data': {
+                'id': str(user.id),
+                'email': user.email,
+                'phone': user.phone_number,
+            },
+        }
         access_token = await auth_service._create_jwt_token(
             subject=user.username,
             token_type=AuthJWTConstants.ACCESS_TOKEN_NAME.value,
             time_unit=AuthJWTConstants.MINUTES.value,
             time_amount=AuthJWTConstants.TOKEN_EXPIRE_60.value,
+            user_claims=user_claims,
         )
         refresh_token = await auth_service._create_jwt_token(
             subject=user.username,
             token_type=AuthJWTConstants.REFRESH_TOKEN_NAME.value,
             time_unit=AuthJWTConstants.DAYS.value,
             time_amount=AuthJWTConstants.TOKEN_EXPIRE_7.value,
-
+            user_claims=user_claims,
         )
         client.cookies.update({AuthJWTConstants.ACCESS_TOKEN_COOKIE_NAME.value: access_token})
         client.cookies.update({AuthJWTConstants.REFRESH_TOKEN_COOKIE_NAME.value: refresh_token})


### PR DESCRIPTION
Hi 👋 team, please review changes that I made in regard of task [[AUTH-2] Add additional information in JWT token](https://github.com/ITA-Dnipro/Dp-Retraining-Python/issues/36) .
Here is the changes:
- Additional user's data: id, email, phone added to JWT access and refresh tokens.
- Fixed tests for the changes.